### PR TITLE
Workflow now only creates release on tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,22 +12,9 @@ jobs:
           root_file: main.tex
       - name: Create Release
         id: create_release
-        uses: gfreezy/create-release@v1.0.5
+        uses: softprops/action-gh-release@v1
+        if: startswith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          allow_duplicate: true
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.event.head_commit.message }}
-          draft: false
-          prerelease: false
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./main.pdf
-          asset_name: main.pdf
-          asset_content_type: application/pdf
+          files: main.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -283,3 +283,6 @@ TSWLatexianTemp*
 # option is specified. Footnotes are the stored in a file with suffix Notes.bib.
 # Uncomment the next line to have this generated file ignored.
 #*Notes.bib
+
+# Temporary vim-files
+*~


### PR DESCRIPTION
Will tag current release as v1.0, remove erroneous tags that created problems